### PR TITLE
Add missing curly braces to twig field item

### DIFF
--- a/craft/templates/services/_index.html
+++ b/craft/templates/services/_index.html
@@ -25,7 +25,7 @@
 					<a href="{{ entry.url }}" class="services-entry-wrap">
 						{% set image = entry.featuredImage.first() %}
 						{% if image %}
-							<img src="{{ image.getUrl('thumb') }}" alt="image.title"/>
+							<img src="{{ image.getUrl('thumb') }}" alt="{{ image.title }}"/>
 						{% endif %}
 
 						<h3 class="center">{{ entry.title }}</h3>


### PR DESCRIPTION
Currently reads `alt="image.title"`
Should read `alt="{{ image.title }}"`